### PR TITLE
Add `typeVersions` field

### DIFF
--- a/.changeset/bright-kiwis-juggle.md
+++ b/.changeset/bright-kiwis-juggle.md
@@ -1,0 +1,7 @@
+---
+"@delvtech/evm-client": patch
+"@delvtech/evm-client-ethers": patch
+"@delvtech/evm-client-viem": patch
+---
+
+Fix type resolutions by adding a `typeVersions` field to the `package.json`s

--- a/packages/evm-client-ethers/package.json
+++ b/packages/evm-client-ethers/package.json
@@ -16,6 +16,13 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "stubs": [
+        "./dist/stubs.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "tsup",
     "lint": "eslint .",

--- a/packages/evm-client-viem/package.json
+++ b/packages/evm-client-viem/package.json
@@ -16,6 +16,13 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "stubs": [
+        "./dist/stubs.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "tsup",
     "lint": "eslint .",

--- a/packages/evm-client/package.json
+++ b/packages/evm-client/package.json
@@ -30,6 +30,25 @@
     },
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "cache": [
+        "./dist/cache.d.ts"
+      ],
+      "contract": [
+        "./dist/contract.d.ts"
+      ],
+      "errors": [
+        "./dist/errors.d.ts"
+      ],
+      "network": [
+        "./dist/network.d.ts"
+      ],
+      "stubs": [
+        "./dist/stubs.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "tsup",
     "lint": "eslint .",


### PR DESCRIPTION
This fixes type errors in projects using `"moduleResolution": "node"` (Next.js 13 requires this).