### PR TITLE
Add ability to stub getEvents with specific filter args

### DIFF
--- a/.changeset/wet-eyes-arrive.md
+++ b/.changeset/wet-eyes-arrive.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client": patch
+---
+
+Add ability to stub events for dynamic filter args

--- a/packages/evm-client/src/contract/factories/CachedReadContract.test.ts
+++ b/packages/evm-client/src/contract/factories/CachedReadContract.test.ts
@@ -45,7 +45,7 @@ describe('createCachedReadContract', () => {
         transactionHash: '0x123abc',
       },
     ];
-    contract.stubEvents('Transfer', stubbedEvents);
+    contract.stubEvents('Transfer', undefined, stubbedEvents);
 
     const events = await cachedContract.getEvents('Transfer');
     expect(events).toBe(stubbedEvents);


### PR DESCRIPTION
This PR adds the missing functionality needed to stub `contract.getEvents` and have the correct values returned depending on dynamic filter args.

**Background**
In the Hyperdrive SDK, `ReadHyperdrive.getOpenLongs()` makes two calls for `TransferSingle` events. The first for longs you opened, and another for the longs you closed.

In order to write a unit test for this method, we need to stub two different getEvents calls:
- open long -> `contract.getEvents('TransferSingle', { from: ZERO_ADDRESS })`
- close long -> `contract.getEvents('TransferSingle', { from: userAddress })`