### PR TITLE
Use a stable stringify for stub keys

### DIFF
--- a/.changeset/metal-boats-battle.md
+++ b/.changeset/metal-boats-battle.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client": patch
+---
+
+Use stable stringify for stub keys

--- a/packages/evm-client/package.json
+++ b/packages/evm-client/package.json
@@ -66,7 +66,8 @@
     }
   },
   "dependencies": {
-    "lru-cache": "^10.0.1"
+    "lru-cache": "^10.0.1",
+    "fast-safe-stringify": "^2.1.1"
   },
   "devDependencies": {
     "@repo/eslint-config": "*",

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.ts
@@ -279,5 +279,5 @@ function stableStringify(obj: Record<any, any>) {
     return typeof v === 'bigint' ? v.toString() : v;
   }
 
-  return stringify(obj, replacer);
+  return stringify.stableStringify(obj, replacer);
 }

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.ts
@@ -1,4 +1,5 @@
 import { Abi } from 'abitype';
+import stringify from 'fast-safe-stringify';
 import { SinonStub, stub } from 'sinon';
 import {
   ContractDecodeFunctionDataArgs,
@@ -168,7 +169,7 @@ export class ReadContractStub<TAbi extends Abi = Abi>
     args: ContractGetEventsOptions<TAbi, TEventName> | undefined,
     value: Event<TAbi, TEventName>[],
   ): void {
-    const stubKey = stringify({ eventName, args });
+    const stubKey = stableStringify({ eventName, args });
     if (this.eventsStubMap.has(stubKey)) {
       this.getEventsStub(eventName, args)!.resolves(value as any);
     } else {
@@ -210,7 +211,7 @@ export class ReadContractStub<TAbi extends Abi = Abi>
     eventName: TEventName,
     args?: ContractGetEventsOptions<TAbi, TEventName> | undefined,
   ): EventsStub<TAbi, TEventName> | undefined {
-    const stubKey = stringify({ eventName, args });
+    const stubKey = stableStringify({ eventName, args });
     return this.eventsStubMap.get(stubKey) as
       | EventsStub<TAbi, TEventName>
       | undefined;
@@ -272,11 +273,11 @@ type SimulateWriteStub<
   Promise<FunctionReturn<TAbi, TFunctionName>>
 >;
 
-function stringify(obj: Record<any, any>) {
+function stableStringify(obj: Record<any, any>) {
   // simple non-recursive stringify replacer for bigints
   function replacer(_: any, v: any) {
     return typeof v === 'bigint' ? v.toString() : v;
   }
 
-  return JSON.stringify(obj, replacer);
+  return stringify(obj, replacer);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,6 +2395,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"


### PR DESCRIPTION
Make it safer to stub arguments in any order and have them resolve correctly to their respective stubbed value.