### PR TITLE
Add options for stubbing read methods

### DIFF
--- a/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
@@ -25,11 +25,15 @@ describe('ReadContractStub', () => {
       functionName: 'balanceOf',
       args: ALICE,
       value: aliceValue,
+      // options can be specfied as well
+      options: { blockNumber: 10n },
     });
 
     // Now try and read them based on their args
     const bobResult = await contract.read('balanceOf', BOB);
-    const aliceResult = await contract.read('balanceOf', ALICE);
+    const aliceResult = await contract.read('balanceOf', ALICE, {
+      blockNumber: 10n,
+    });
     expect(bobResult).toBe(bobValue);
     expect(aliceResult).toBe(aliceValue);
 

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.ts
@@ -117,10 +117,12 @@ export class ReadContractStub<TAbi extends Abi = Abi>
     functionName,
     args,
     value,
+    options,
   }: {
     functionName: TFunctionName;
     args?: FunctionArgs<TAbi, TFunctionName>;
     value: FunctionReturn<TAbi, TFunctionName>;
+    options?: ContractReadOptions
   }): void {
     let readStub = this.readStubMap.get(functionName);
     if (!readStub) {
@@ -130,7 +132,7 @@ export class ReadContractStub<TAbi extends Abi = Abi>
 
     // Account for dynamic args if provided
     if (args) {
-      readStub.withArgs(args).resolves(value);
+      readStub.withArgs(args, options).resolves(value);
       return;
     }
 


### PR DESCRIPTION
Since we're calling `getPoolInfo` at different blocks, we need to be able to stub the result given specific block numbers, which are separate parameters than the contract's arguments.