### PR TITLE
Use options in stub lookup

### DIFF
--- a/.changeset/thin-papayas-fold.md
+++ b/.changeset/thin-papayas-fold.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client": patch
+---
+
+Fix bug causing stub lookups to fail

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
@@ -7,6 +7,34 @@ import { describe, expect, it } from 'vitest';
 const ERC20ABI = IERC20.abi;
 
 describe('ReadContractStub', () => {
+  it('stubs the read function without args, but with options', async () => {
+    const contract = new ReadContractStub(IERC20.abi);
+
+    // stub total supply
+    contract.stubRead({
+      functionName: 'totalSupply',
+      value: 30n,
+      // options can be specfied as well
+      options: { blockNumber: 12n },
+    });
+    contract.stubRead({
+      functionName: 'totalSupply',
+      value: 40n,
+      // options can be specfied as well
+      options: { blockNumber: 16n },
+    });
+    // Now try and read them based on their args
+    const totalSupplyAtBlock12 = await contract.read('totalSupply', undefined, {
+      blockNumber: 12n,
+    });
+    expect(totalSupplyAtBlock12).toBe(30n);
+
+    const totalSupplyAtBlock16 = await contract.read('totalSupply', undefined, {
+      blockNumber: 16n,
+    });
+    expect(totalSupplyAtBlock16).toBe(40n);
+  });
+
   it('stubs the read function', async () => {
     const contract = new ReadContractStub(IERC20.abi);
 

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.ts
@@ -131,7 +131,7 @@ export class ReadContractStub<TAbi extends Abi = Abi>
     }
 
     // Account for dynamic args if provided
-    if (args) {
+    if (args || options) {
       readStub.withArgs(args, options).resolves(value);
       return;
     }


### PR DESCRIPTION
Followup to #36 

We forgot to include `options` in the lookup for the stub.