### PR TITLE
Change all input types to objects (no single values)

### DIFF
--- a/.changeset/long-boats-hide.md
+++ b/.changeset/long-boats-hide.md
@@ -1,0 +1,7 @@
+---
+"@delvtech/evm-client-ethers": minor
+"@delvtech/evm-client-viem": minor
+"@delvtech/evm-client": minor
+---
+
+Changed the type of all inputs to objects. This means that functions with a single argument (e.g., `balanceOf` will now expect ```{ owner: `0x${string}` }```, not ``` `0x${string}` ```). Outputs remain the "Friendly" type which deconstructs to a single primitive type for single outputs values (e.g., `symbol` will return a `string`, not `{ "0": string }`) since many single output return values are unnamed

--- a/packages/evm-client-ethers/src/contract/createReadContract.ts
+++ b/packages/evm-client-ethers/src/contract/createReadContract.ts
@@ -1,11 +1,12 @@
 import {
   AbiEntryNotFoundError,
-  arrayToFriendly,
   DecodedFunctionData,
-  friendlyToArray,
   FunctionName,
   ReadContract,
   ReadWriteContract,
+  arrayToFriendly,
+  arrayToObject,
+  objectToArray,
 } from '@delvtech/evm-client';
 import { Abi } from 'abitype';
 import { Contract, EventLog, InterfaceAbi, Provider, Signer } from 'ethers';
@@ -52,7 +53,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     async read(functionName, args, options) {
-      const argsArray: any[] = friendlyToArray({
+      const argsArray: any[] = objectToArray({
         abi: abi as Abi,
         type: 'function',
         name: functionName,
@@ -81,7 +82,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     async simulateWrite(functionName, args, options) {
-      const argsArray: any[] = friendlyToArray({
+      const argsArray: any[] = objectToArray({
         abi: abi as Abi,
         type: 'function',
         name: functionName,
@@ -110,7 +111,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     async getEvents(eventName, options) {
-      const filterValues = friendlyToArray({
+      const filterValues = objectToArray({
         // Cast to allow any array type for values
         abi: abi as Abi,
         type: 'event',
@@ -127,7 +128,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
       )) as EventLog[];
 
       return events.map(({ blockNumber, data, transactionHash, args }) => {
-        const friendlyArgs = arrayToFriendly({
+        const objectArgs = arrayToObject({
           // Cast to allow any array type for values
           abi: abi as Abi,
           type: 'event',
@@ -137,7 +138,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
         });
 
         return {
-          args: friendlyArgs,
+          args: objectArgs,
           blockNumber: BigInt(blockNumber),
           data: data as `0x${string}`,
           eventName,
@@ -147,7 +148,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     encodeFunctionData(functionName, args) {
-      const arrayArgs = friendlyToArray({
+      const arrayArgs = objectToArray({
         // Cast to allow any array type for values
         abi: abi as Abi,
         type: 'function',
@@ -183,7 +184,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
       }
 
       return {
-        args: arrayToFriendly({
+        args: arrayToObject({
           abi: abi as Abi,
           type: 'function',
           name: parsed.name,

--- a/packages/evm-client-ethers/src/contract/createReadWriteContract.ts
+++ b/packages/evm-client-ethers/src/contract/createReadWriteContract.ts
@@ -1,5 +1,5 @@
 import {
-  friendlyToArray,
+  objectToArray,
   ReadContract,
   ReadWriteContract,
 } from '@delvtech/evm-client';
@@ -41,7 +41,7 @@ export function createReadWriteContract<TAbi extends Abi = Abi>({
     },
 
     async write(functionName, args, options) {
-      const argsArray = friendlyToArray({
+      const argsArray = objectToArray({
         abi: abi as Abi,
         type: 'function',
         name: functionName,

--- a/packages/evm-client-ethers/src/index.ts
+++ b/packages/evm-client-ethers/src/index.ts
@@ -25,14 +25,17 @@ export * from '@delvtech/evm-client/cache';
 
 export {
   arrayToFriendly,
-  friendlyToArray,
+  arrayToObject,
   getAbiEntry,
+  objectToArray,
 } from '@delvtech/evm-client/contract';
 export type {
   AbiArrayType,
   AbiEntry,
   AbiEntryName,
   AbiFriendlyType,
+  AbiObjectType,
+  AbiParameters,
   CachedReadContract,
   CachedReadWriteContract,
   ContractDecodeFunctionDataArgs,

--- a/packages/evm-client-viem/src/contract/createReadContract.ts
+++ b/packages/evm-client-viem/src/contract/createReadContract.ts
@@ -1,12 +1,12 @@
 import {
+  AbiObjectType,
   DecodedFunctionData,
-  Event,
   FunctionName,
   FunctionReturn,
   ReadContract,
   ReadWriteContract,
-  arrayToFriendly,
-  friendlyToArray,
+  arrayToObject,
+  objectToArray,
 } from '@delvtech/evm-client';
 import { createSimulateContractParameters } from 'src/contract/utils/createSimulateContractParameters';
 import {
@@ -58,7 +58,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     async read(functionName, args, options) {
-      const argsArray = friendlyToArray({
+      const argsArray = objectToArray({
         abi,
         type: 'function',
         name: functionName,
@@ -82,7 +82,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
     },
 
     async simulateWrite(functionName, args, options) {
-      const argsArray = friendlyToArray({
+      const argsArray = objectToArray({
         abi,
         type: 'function',
         name: functionName,
@@ -118,28 +118,28 @@ export function createReadContract<TAbi extends Abi = Abi>({
       const events = await publicClient.getFilterLogs({ filter });
 
       return events.map(({ args, blockNumber, data, transactionHash }) => {
-        const friendlyArgs = Array.isArray(args)
-          ? arrayToFriendly({
+        const objectArgs = Array.isArray(args)
+          ? arrayToObject({
               abi: abi as Abi,
               type: 'event',
               name: eventName,
               kind: 'inputs',
-              values: args as readonly unknown[],
+              values: args,
             })
-          : args;
+          : (args as AbiObjectType<TAbi, 'event', typeof eventName, 'inputs'>);
 
         return {
-          args: friendlyArgs,
+          args: objectArgs,
           blockNumber: blockNumber ?? undefined,
           data,
           eventName,
           transactionHash: transactionHash ?? undefined,
         };
-      }) as Event<TAbi, typeof eventName>[];
+      });
     },
 
     encodeFunctionData(functionName, args) {
-      const arrayArgs = friendlyToArray({
+      const arrayArgs = objectToArray({
         abi: abi,
         type: 'function',
         name: functionName,
@@ -165,7 +165,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
       const arrayArgs = Array.isArray(args) ? args : [args];
 
       return {
-        args: arrayToFriendly({
+        args: arrayToObject({
           // Cast to allow any array type for values
           abi: abi as Abi,
           type: 'function',

--- a/packages/evm-client-viem/src/contract/createReadWriteContract.ts
+++ b/packages/evm-client-viem/src/contract/createReadWriteContract.ts
@@ -1,5 +1,5 @@
 import {
-  friendlyToArray,
+  objectToArray,
   ReadContract,
   ReadWriteContract,
 } from '@delvtech/evm-client';
@@ -50,7 +50,7 @@ export function createReadWriteContract<TAbi extends Abi = Abi>({
     async write(functionName, args, options) {
       const [account] = await walletClient.getAddresses();
 
-      const arrayArgs = friendlyToArray({
+      const arrayArgs = objectToArray({
         abi: abi,
         type: 'function',
         name: functionName,

--- a/packages/evm-client-viem/src/index.ts
+++ b/packages/evm-client-viem/src/index.ts
@@ -25,14 +25,17 @@ export * from '@delvtech/evm-client/cache';
 
 export {
   arrayToFriendly,
-  friendlyToArray,
+  arrayToObject,
   getAbiEntry,
+  objectToArray,
 } from '@delvtech/evm-client/contract';
 export type {
   AbiArrayType,
   AbiEntry,
   AbiEntryName,
   AbiFriendlyType,
+  AbiObjectType,
+  AbiParameters,
   CachedReadContract,
   CachedReadWriteContract,
   ContractDecodeFunctionDataArgs,

--- a/packages/evm-client/README.md
+++ b/packages/evm-client/README.md
@@ -62,21 +62,24 @@ The API is meant to be easy to both read and write.
 
 #### Utils
 
+- **[`objectToArray`](./src/contract/utils/friendlyToArray.ts):** A function
+  that takes an object of inputs (function and event arguments) and converts it
+  into an array, ensuring parameters are properly ordered and the correct number
+  of parameters are present.
+
+- **[`arrayToObject`](./src/contract/utils/arrayToFriendly.ts):** The opposite
+  of `objectToArray`. A function to transform contract input and output arrays
+  into objects.
+
 - **[`arrayToFriendly`](./src/contract/utils/arrayToFriendly.ts):** A function
-  to transform contract input and output arrays into "Friendly" types. The
-  friendly type of an input/output array depends on the number of input/output
-  parameters:
+  to transform contract output arrays into "Friendly" types. The friendly type
+  of an output array depends on the number of output parameters:
 
   - Multiple parameters: An object with the argument names as keys (or their
     index if no name is found in the ABI) and the primitive type of the
     parameters as values.
   - Single parameters: The primitive type of the single parameter.
   - No parameters: `undefined`
-
-- **[`friendlyToArray`](./src/contract/utils/friendlyToArray.ts):** The opposite
-  of `arrayToFriendly`. A function that takes a "Friendly" type and converts it
-  into an array, ensuring parameters are properly ordered and the correct number
-  of parameters are present.
 
 #### Factories
 
@@ -103,13 +106,13 @@ information like blocks and transactions.
 
 #### Stubs
 
-- **[`NetworkStub`](./src/network/stubs/NetworkStub.ts):** A stub of a
-  `Network` for use in tests.
+- **[`NetworkStub`](./src/network/stubs/NetworkStub.ts):** A stub of a `Network`
+  for use in tests.
 
 ### SimpleCache
 
-A simple cache abstraction providing a minimal interface for facilitating contract
-caching.
+A simple cache abstraction providing a minimal interface for facilitating
+contract caching.
 
 #### Types
 

--- a/packages/evm-client/src/contract/factories/CachedReadContract.test.ts
+++ b/packages/evm-client/src/contract/factories/CachedReadContract.test.ts
@@ -64,12 +64,14 @@ describe('createCachedReadContract', () => {
     const stubbedValue = 100n;
     contract.stubRead({ functionName: 'balanceOf', value: stubbedValue });
 
-    const value = await cachedContract.read('balanceOf', '0x123abc');
+    const value = await cachedContract.read('balanceOf', { owner: '0x123abc' });
     expect(value).toBe(stubbedValue);
 
-    cachedContract.deleteRead('balanceOf', '0x123abc');
+    cachedContract.deleteRead('balanceOf', { owner: '0x123abc' });
 
-    const value2 = await cachedContract.read('balanceOf', '0x123abc');
+    const value2 = await cachedContract.read('balanceOf', {
+      owner: '0x123abc',
+    });
     expect(value2).toBe(stubbedValue);
 
     const stub = contract.getReadStub('balanceOf');
@@ -81,18 +83,17 @@ describe('createCachedReadContract', () => {
     const cachedContract = createCachedReadContract({ contract });
 
     contract.stubRead({ functionName: 'balanceOf', value: 100n });
-    const stubbedValue = '0x123abc';
     contract.stubRead({
       functionName: 'name',
-      value: stubbedValue,
+      value: 'Base Token',
     });
-    2;
-    await cachedContract.read('balanceOf', '0x123abc');
+
+    await cachedContract.read('balanceOf', { owner: '0x123abc' });
     await cachedContract.read('name');
 
     cachedContract.clearCache();
 
-    await cachedContract.read('balanceOf', '0x123abc');
+    await cachedContract.read('balanceOf', { owner: '0x123abc' });
     await cachedContract.read('name');
 
     const stubA = contract.getReadStub('balanceOf');

--- a/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
+++ b/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
@@ -32,8 +32,8 @@ export function createCachedReadWriteContract<TAbi extends Abi = Abi>({
   };
 }
 
-function isCached(
-  contract: ReadWriteContract | CachedReadWriteContract,
-): contract is CachedReadWriteContract {
+function isCached<TAbi extends Abi>(
+  contract: ReadWriteContract<TAbi> | CachedReadWriteContract<TAbi>,
+): contract is CachedReadWriteContract<TAbi> {
   return 'clearCache' in contract;
 }

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.test.ts
@@ -38,30 +38,32 @@ describe('ReadContractStub', () => {
   it('stubs the read function', async () => {
     const contract = new ReadContractStub(IERC20.abi);
 
-    expect(contract.read('balanceOf', NANCY)).rejects.toThrowError();
+    expect(contract.read('balanceOf', { owner: NANCY })).rejects.toThrowError();
 
     // Stub bob and alice's balances first
     const bobValue = 10n;
     contract.stubRead({
       functionName: 'balanceOf',
-      args: BOB,
+      args: { owner: BOB },
       value: bobValue,
     });
 
     const aliceValue = 20n;
     contract.stubRead({
       functionName: 'balanceOf',
-      args: ALICE,
+      args: { owner: ALICE },
       value: aliceValue,
       // options can be specfied as well
       options: { blockNumber: 10n },
     });
 
     // Now try and read them based on their args
-    const bobResult = await contract.read('balanceOf', BOB);
-    const aliceResult = await contract.read('balanceOf', ALICE, {
-      blockNumber: 10n,
-    });
+    const bobResult = await contract.read('balanceOf', { owner: BOB });
+    const aliceResult = await contract.read(
+      'balanceOf',
+      { owner: ALICE },
+      { blockNumber: 10n },
+    );
     expect(bobResult).toBe(bobValue);
     expect(aliceResult).toBe(aliceValue);
 
@@ -71,7 +73,7 @@ describe('ReadContractStub', () => {
       functionName: 'balanceOf',
       value: defaultValue,
     });
-    const defaultResult = await contract.read('balanceOf', NANCY);
+    const defaultResult = await contract.read('balanceOf', { owner: NANCY });
     expect(defaultResult).toBe(defaultValue);
 
     const stub = contract.getReadStub('balanceOf');

--- a/packages/evm-client/src/contract/stubs/ReadContractStub.ts
+++ b/packages/evm-client/src/contract/stubs/ReadContractStub.ts
@@ -122,7 +122,7 @@ export class ReadContractStub<TAbi extends Abi = Abi>
     functionName: TFunctionName;
     args?: FunctionArgs<TAbi, TFunctionName>;
     value: FunctionReturn<TAbi, TFunctionName>;
-    options?: ContractReadOptions
+    options?: ContractReadOptions;
   }): void {
     let readStub = this.readStubMap.get(functionName);
     if (!readStub) {
@@ -132,7 +132,11 @@ export class ReadContractStub<TAbi extends Abi = Abi>
 
     // Account for dynamic args if provided
     if (args || options) {
-      readStub.withArgs(args, options).resolves(value);
+      // The stub returned from the map doesn't have a strong FunctionName type
+      // so we have to cast to avoid contravariance errors with the args.
+      (readStub as ReadStub<TAbi, TFunctionName>)
+        .withArgs(args, options)
+        .resolves(value);
       return;
     }
 

--- a/packages/evm-client/src/contract/types/AbiEntry.ts
+++ b/packages/evm-client/src/contract/types/AbiEntry.ts
@@ -50,89 +50,23 @@ export type AbiEntry<
 >;
 
 /**
- * Get an array of primitive types for any ABI parameters.
+ * Get the parameters for a specific ABI entry.
  *
  * @example
- * type ApproveInput = AbiArrayType<Erc20Abi, "function", "approve", "inputs">;
- * // -> [`${string}`, bigint]
- *
- * type BalanceOutput = AbiArrayType<Erc20Abi, "function", "balanceOf", "outputs">;
- * // -> [bigint]
+ * type ApproveParameters = AbiParameters<Erc20Abi, "function", "approve", "inputs">;
+ * // -> [{ name: "spender", type: "address" }, { name: "value", type: "uint256" }]
  */
-// TODO: This might be able to have a couple steps removed
-export type AbiArrayType<
-  TAbi extends Abi,
+export type AbiParameters<
+  TAbi extends Abi = Abi,
   TItemType extends AbiItemType = AbiItemType,
   TName extends AbiEntryName<TAbi, TItemType> = AbiEntryName<TAbi, TItemType>,
   TParameterKind extends AbiParameterKind = AbiParameterKind,
 > =
   AbiEntry<TAbi, TItemType, TName> extends infer TAbiEntry
     ? TParameterKind extends keyof TAbiEntry
-      ? TAbiEntry[TParameterKind] extends infer TParameters
-        ? TParameters extends readonly AbiParameter[]
-          ? AbiParametersToPrimitiveTypes<TParameters>
-          : TParameters
-        : []
+      ? TAbiEntry[TParameterKind]
       : []
     : [];
-
-/**
- * Convert an array or tuple of abi parameters to an object type.
- *
- * @example
- * type ApproveArgs = AbiParametersToObject<Erc20Abi, "function", "approve", "inputs">;
- * // -> { spender: `${string}`, value: bigint }
- */
-export type AbiParametersToObject<
-  TParameters extends readonly AbiParameter[],
-  TParameterKind extends AbiParameterKind = AbiParameterKind,
-> = TParameters extends readonly []
-  ? EmptyObject
-  : TParameters extends NamedAbiParameter[]
-    ? NamedParametersToObject<TParameters, TParameterKind>
-    : NamedParametersToObject<WithDefaultNames<TParameters>, TParameterKind>;
-
-/**
- * Get a user-friendly primitive type for any ABI parameters, which is
- * determined by the number of parameters:
- * - __Single parameter:__ the primitive type of the parameter.
- * - __Multiple parameters:__ an object with the parameter names as keys and the
- *   their primitive types as values. If a parameter has no name, it's index is
- *   used as the key.
- * - __No parameters:__ `undefined`.
- *
- * @example
- * type ApproveArgs = AbiFriendlyType<Erc20Abi, "function", "approve", "inputs">;
- * // -> { spender: `${string}`, value: bigint }
- *
- * type Balance = AbiFriendlyType<Erc20Abi, "function", "balanceOf", "outputs">;
- * // -> bigint
- *
- * type DecimalArgs = AbiFriendlyType<Erc20Abi, "function", "decimals", "inputs">;
- * // -> undefined
- */
-export type AbiFriendlyType<
-  TAbi extends Abi,
-  TItemType extends AbiItemType = AbiItemType,
-  TName extends AbiEntryName<TAbi, TItemType> = AbiEntryName<TAbi, TItemType>,
-  TParameterKind extends AbiParameterKind = AbiParameterKind,
-  TStateMutability extends AbiStateMutability = AbiStateMutability,
-> =
-  AbiEntry<TAbi, TItemType, TName, TStateMutability> extends infer TAbiEntry
-    ? TParameterKind extends keyof TAbiEntry & AbiParameterKind // Check if the ABI entry includes the parameter kind (inputs/outputs)
-      ? TAbiEntry[TParameterKind] extends readonly [AbiParameter] // Check if it's a single parameter
-        ? AbiParameterToPrimitiveType<
-            TAbiEntry[TParameterKind][0],
-            TParameterKind
-          > // Single parameter type
-        : TAbiEntry[TParameterKind] extends readonly [
-              AbiParameter,
-              ...AbiParameter[],
-            ] // Check if it's multiple parameters
-          ? AbiParametersToObject<TAbiEntry[TParameterKind], TParameterKind> // Multiple parameters type
-          : undefined // Empty parameters
-      : undefined // ABI entry doesn't include the parameter kind (inputs/outputs)
-    : undefined; // ABI entry not found
 
 /**
  * Add default names to any ABI parameters that are missing a name. The default
@@ -195,3 +129,109 @@ type NamedParametersToObject<
           >;
         })
 >;
+
+/**
+ * Convert an array or tuple of abi parameters to an object type.
+ *
+ * @example
+ * type ApproveArgs = AbiParametersToObject<[
+ *   { name: "spender", type: "address" },
+ *   { name: "value", type: "uint256" }
+ * ]>; // -> { spender: `${string}`, value: bigint }
+ */
+export type AbiParametersToObject<
+  TParameters extends readonly AbiParameter[],
+  TParameterKind extends AbiParameterKind = AbiParameterKind,
+> = TParameters extends readonly []
+  ? EmptyObject
+  : TParameters extends NamedAbiParameter[]
+    ? NamedParametersToObject<TParameters, TParameterKind>
+    : NamedParametersToObject<WithDefaultNames<TParameters>, TParameterKind>;
+
+/**
+ * Get an array of primitive types for any ABI parameters.
+ *
+ * @example
+ * type ApproveInput = AbiArrayType<Erc20Abi, "function", "approve", "inputs">;
+ * // -> [`${string}`, bigint]
+ *
+ * type BalanceOutput = AbiArrayType<Erc20Abi, "function", "balanceOf", "outputs">;
+ * // -> [bigint]
+ */
+export type AbiArrayType<
+  TAbi extends Abi,
+  TItemType extends AbiItemType = AbiItemType,
+  TName extends AbiEntryName<TAbi, TItemType> = AbiEntryName<TAbi, TItemType>,
+  TParameterKind extends AbiParameterKind = AbiParameterKind,
+> =
+  AbiParameters<
+    TAbi,
+    TItemType,
+    TName,
+    TParameterKind
+  > extends infer TParameters
+    ? TParameters extends readonly AbiParameter[]
+      ? AbiParametersToPrimitiveTypes<TParameters>
+      : []
+    : [];
+
+/**
+ * Get an object of primitive types for any ABI parameters.
+ *
+ * @example
+ * type ApproveArgs = AbiObjectType<Erc20Abi, "function", "approve", "inputs">;
+ * // -> { spender: `${string}`, value: bigint }
+ *
+ * type Balance = AbiObjectType<Erc20Abi, "function", "balanceOf", "outputs">;
+ * // -> { balance: bigint }
+ */
+export type AbiObjectType<
+  TAbi extends Abi,
+  TItemType extends AbiItemType = AbiItemType,
+  TName extends AbiEntryName<TAbi, TItemType> = AbiEntryName<TAbi, TItemType>,
+  TParameterKind extends AbiParameterKind = AbiParameterKind,
+> = AbiParametersToObject<
+  AbiParameters<TAbi, TItemType, TName, TParameterKind>
+>;
+
+/**
+ * Get a user-friendly primitive type for any ABI parameters, which is
+ * determined by the number of parameters:
+ * - __Single parameter:__ the primitive type of the parameter.
+ * - __Multiple parameters:__ an object with the parameter names as keys and the
+ *   their primitive types as values. If a parameter has no name, it's index is
+ *   used as the key.
+ * - __No parameters:__ `undefined`.
+ *
+ * @example
+ * type ApproveArgs = AbiFriendlyType<Erc20Abi, "function", "approve", "inputs">;
+ * // -> { spender: `${string}`, value: bigint }
+ *
+ * type Balance = AbiFriendlyType<Erc20Abi, "function", "balanceOf", "outputs">;
+ * // -> bigint
+ *
+ * type DecimalArgs = AbiFriendlyType<Erc20Abi, "function", "decimals", "inputs">;
+ * // -> undefined
+ */
+export type AbiFriendlyType<
+  TAbi extends Abi,
+  TItemType extends AbiItemType = AbiItemType,
+  TName extends AbiEntryName<TAbi, TItemType> = AbiEntryName<TAbi, TItemType>,
+  TParameterKind extends AbiParameterKind = AbiParameterKind,
+  TStateMutability extends AbiStateMutability = AbiStateMutability,
+> =
+  AbiEntry<TAbi, TItemType, TName, TStateMutability> extends infer TAbiEntry
+    ? TParameterKind extends keyof TAbiEntry & AbiParameterKind // Check if the ABI entry includes the parameter kind (inputs/outputs)
+      ? TAbiEntry[TParameterKind] extends readonly [AbiParameter] // Check if it's a single parameter
+        ? AbiParameterToPrimitiveType<
+            TAbiEntry[TParameterKind][0],
+            TParameterKind
+          > // Single parameter type
+        : TAbiEntry[TParameterKind] extends readonly [
+              AbiParameter,
+              ...AbiParameter[],
+            ] // Check if it's multiple parameters
+          ? AbiParametersToObject<TAbiEntry[TParameterKind], TParameterKind> // Multiple parameters type
+          : undefined // Empty parameters
+      : undefined // ABI entry doesn't include the parameter kind (inputs/outputs)
+    : undefined; // ABI entry not found

--- a/packages/evm-client/src/contract/types/Contract.ts
+++ b/packages/evm-client/src/contract/types/Contract.ts
@@ -1,4 +1,5 @@
 import { Abi } from 'abitype';
+import { EmptyObject } from 'src/base/types';
 import { Event, EventFilter, EventName } from 'src/contract/types/Event';
 import {
   DecodedFunctionData,
@@ -97,10 +98,10 @@ export type ContractReadArgs<
   TAbi extends Abi,
   TFunctionName extends FunctionName<TAbi>,
 > =
-  FunctionArgs<TAbi, TFunctionName> extends undefined
+  FunctionArgs<TAbi, TFunctionName> extends EmptyObject
     ? [
         functionName: TFunctionName,
-        args?: undefined,
+        args?: FunctionArgs<TAbi, TFunctionName>,
         options?: ContractReadOptions,
       ]
     : [
@@ -168,10 +169,10 @@ export type ContractWriteArgs<
   TAbi extends Abi,
   TFunctionName extends FunctionName<TAbi, 'nonpayable' | 'payable'>,
 > =
-  FunctionArgs<TAbi, TFunctionName> extends undefined
+  FunctionArgs<TAbi, TFunctionName> extends EmptyObject
     ? [
         functionName: TFunctionName,
-        args?: undefined,
+        args?: FunctionArgs<TAbi, TFunctionName>,
         options?: ContractWriteOptions,
       ]
     : [
@@ -184,8 +185,8 @@ export type ContractEncodeFunctionDataArgs<
   TAbi extends Abi,
   TFunctionName extends FunctionName<TAbi>,
 > =
-  FunctionArgs<TAbi, TFunctionName> extends undefined
-    ? [functionName: TFunctionName, args?: undefined]
+  FunctionArgs<TAbi, TFunctionName> extends EmptyObject
+    ? [functionName: TFunctionName, args?: FunctionArgs<TAbi, TFunctionName>]
     : [functionName: TFunctionName, args: FunctionArgs<TAbi, TFunctionName>];
 
 export type ContractDecodeFunctionDataArgs = [data: `0x${string}`];

--- a/packages/evm-client/src/contract/types/Event.ts
+++ b/packages/evm-client/src/contract/types/Event.ts
@@ -1,8 +1,8 @@
 import { Abi } from 'abitype';
-import { EmptyObject } from 'src/base/types';
 import {
   AbiEntry,
-  AbiFriendlyType,
+  AbiObjectType,
+  AbiParameters,
   AbiParametersToObject,
   NamedAbiParameter,
 } from 'src/contract/types/AbiEntry';
@@ -19,22 +19,17 @@ type NamedEventInput<
   TAbi extends Abi,
   TEventName extends EventName<TAbi>,
 > = Extract<
-  AbiEntry<TAbi, 'event', TEventName>['inputs'][number],
+  AbiParameters<TAbi, 'event', TEventName, 'inputs'>,
   NamedAbiParameter
 >;
 
 /**
- * Get a user-friendly argument type for an abi event, which is determined by
- * it's inputs:
- * - __Single input:__ the type of the single input.
- * - __Multiple inputs:__ an object with the input names as keys and the input
- *   types as values.
- * - __No inputs:__ `undefined`.
+ * Get an object type for an event's arguments from an abi.
  */
 export type EventArgs<
   TAbi extends Abi,
   TEventName extends EventName<TAbi>,
-> = AbiFriendlyType<TAbi, 'event', TEventName, 'inputs'>;
+> = AbiObjectType<TAbi, 'event', TEventName, 'inputs'>;
 
 /**
  * Get a union of indexed input objects for an event from an abi
@@ -45,20 +40,14 @@ type IndexedEventInput<
 > = Extract<NamedEventInput<TAbi, TEventName>, { indexed: true }>;
 
 /**
- * Get an object type for an event's indexed fields from an abi or `undefined`
- * if there are no indexed fields.
+ * Get an object type for an event's indexed fields from an abi
  */
-export type EventFilter<TAbi extends Abi, TEventName extends EventName<TAbi>> =
-  AbiParametersToObject<
-    IndexedEventInput<TAbi, TEventName>[],
-    'inputs'
-  > extends infer TParamObject
-    ? TParamObject extends EmptyObject
-      ? undefined
-      : Partial<
-          AbiParametersToObject<IndexedEventInput<TAbi, TEventName>[], 'inputs'>
-        >
-    : never;
+export type EventFilter<
+  TAbi extends Abi,
+  TEventName extends EventName<TAbi>,
+> = Partial<
+  AbiParametersToObject<IndexedEventInput<TAbi, TEventName>[], 'inputs'>
+>;
 
 /**
  * A strongly typed event object based on an abi

--- a/packages/evm-client/src/contract/types/Function.ts
+++ b/packages/evm-client/src/contract/types/Function.ts
@@ -1,5 +1,5 @@
 import { Abi, AbiStateMutability } from 'abitype';
-import { AbiEntry, AbiFriendlyType } from 'src/contract/types/AbiEntry';
+import { AbiFriendlyType, AbiObjectType } from 'src/contract/types/AbiEntry';
 
 /**
  * Get a union of function names from an abi
@@ -8,22 +8,17 @@ export type FunctionName<
   TAbi extends Abi,
   TAbiStateMutability extends AbiStateMutability = AbiStateMutability,
 > = Extract<
-  AbiEntry<TAbi, 'function'>,
-  { stateMutability: TAbiStateMutability }
+  TAbi[number],
+  { type: 'function'; stateMutability: TAbiStateMutability }
 >['name'];
 
 /**
- * Get a user-friendly argument type for an abi function, which is determined by
- * it's inputs:
- * - __Single input:__ the type of the single input.
- * - __Multiple inputs:__ an object with the input names as keys and the input
- *   types as values.
- * - __No inputs:__ `undefined` or an empty object.
+ * Get an object type for an abi function's arguments.
  */
 export type FunctionArgs<
   TAbi extends Abi,
   TFunctionName extends FunctionName<TAbi> = FunctionName<TAbi>,
-> = AbiFriendlyType<TAbi, 'function', TFunctionName, 'inputs'>;
+> = AbiObjectType<TAbi, 'function', TFunctionName, 'inputs'>;
 
 /**
  * Get a user-friendly return type for an abi function, which is determined by

--- a/packages/evm-client/src/contract/utils/arrayToObject.test.ts
+++ b/packages/evm-client/src/contract/utils/arrayToObject.test.ts
@@ -1,0 +1,54 @@
+import { IERC20 } from 'src/base/testing/IERC20';
+import { arrayToObject } from 'src/contract/utils/arrayToObject';
+import { describe, expect, it } from 'vitest';
+
+describe('arrayToObject', () => {
+  it('correctly converts arrays into objects', async () => {
+    const transferArgsObject = arrayToObject({
+      abi: IERC20.abi,
+      type: 'function',
+      name: 'transfer',
+      kind: 'inputs',
+      values: ['0x123', 123n],
+    });
+    expect(transferArgsObject).toEqual({
+      to: '0x123',
+      value: 123n,
+    });
+
+    // empty parameter names (index keys)
+    const votesArgsObject = arrayToObject({
+      abi: exampleAbi,
+      type: 'function',
+      name: 'votes',
+      kind: 'inputs',
+      values: ['0x123', 0n],
+    });
+    expect(votesArgsObject).toEqual({
+      '0': '0x123',
+      '1': 0n,
+    });
+
+    const balanceInput = arrayToObject({
+      abi: IERC20.abi,
+      type: 'function',
+      name: 'balanceOf',
+      kind: 'inputs',
+      values: ['0x123'],
+    });
+    expect(balanceInput).toEqual({ owner: '0x123' });
+  });
+});
+
+export const exampleAbi = [
+  {
+    inputs: [
+      { name: '', type: 'address' },
+      { name: '', type: 'uint256' },
+    ],
+    name: 'votes',
+    outputs: [],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;

--- a/packages/evm-client/src/contract/utils/objectToArray.test.ts
+++ b/packages/evm-client/src/contract/utils/objectToArray.test.ts
@@ -1,10 +1,10 @@
 import { IERC20 } from 'src/base/testing/IERC20';
-import { friendlyToArray } from 'src/contract/utils/friendlyToArray';
+import { objectToArray } from 'src/contract/utils/objectToArray';
 import { describe, expect, it } from 'vitest';
 
-describe('friendlyToArray', () => {
-  it('correctly converts object into arrays', async () => {
-    const transferArgsArray = friendlyToArray({
+describe('objectToArray', () => {
+  it('correctly converts objects into arrays', async () => {
+    const transferArgsArray = objectToArray({
       abi: IERC20.abi,
       type: 'function',
       name: 'transfer',
@@ -17,7 +17,7 @@ describe('friendlyToArray', () => {
     expect(transferArgsArray).toEqual(['0x123', 123n]);
 
     // empty parameter names (index keys)
-    const votesArgsArray = friendlyToArray({
+    const votesArgsArray = objectToArray({
       abi: exampleAbi,
       type: 'function',
       name: 'votes',
@@ -30,27 +30,22 @@ describe('friendlyToArray', () => {
     expect(votesArgsArray).toEqual(['0x123', 0n]);
   });
 
-  it('correctly converts single values into arrays', async () => {
-    const balanceInputArray = friendlyToArray({
-      abi: IERC20.abi,
-      type: 'function',
-      name: 'balanceOf',
-      kind: 'inputs',
-      value: '0x123',
-    });
-    expect(balanceInputArray).toEqual(['0x123']);
+  const emptyArray = objectToArray({
+    abi: IERC20.abi,
+    type: 'function',
+    name: 'symbol',
+    kind: 'inputs',
+    value: {},
   });
+  expect(emptyArray).toEqual([]);
 
-  it('converts undefined into an empty array', async () => {
-    const emptyArray = friendlyToArray({
-      abi: IERC20.abi,
-      type: 'function',
-      name: 'symbol',
-      kind: 'inputs',
-      value: undefined,
-    });
-    expect(emptyArray).toEqual([]);
+  const emptyArrayFromUndefined = objectToArray({
+    abi: IERC20.abi,
+    type: 'function',
+    name: 'symbol',
+    kind: 'inputs',
   });
+  expect(emptyArrayFromUndefined).toEqual([]);
 });
 
 export const exampleAbi = [

--- a/packages/evm-client/src/contract/utils/objectToArray.ts
+++ b/packages/evm-client/src/contract/utils/objectToArray.ts
@@ -1,0 +1,93 @@
+import { Abi, AbiItemType, AbiParameter, AbiParameterKind } from 'abitype';
+import {
+  AbiArrayType,
+  AbiEntryName,
+  AbiObjectType,
+} from 'src/contract/types/AbiEntry';
+import { getAbiEntry } from 'src/contract/utils/getAbiEntry';
+
+/**
+ * Converts an object into an array of input or output values, ensuring the the
+ * correct number and order of values are present.
+ *
+ * @example
+ * const abi = [
+ *   {
+ *     type: "function",
+ *     name: "transfer",
+ *     inputs: [
+ *       { name: "to", type: "address" },
+ *       { name: "value", type: "uint256" },
+ *     ],
+ *     outputs: [{ name: "", type: "bool" }],
+ *     stateMutability: "nonpayable",
+ *   },
+ *   {
+ *     type: "event",
+ *     name: "Approval",
+ *     inputs: [
+ *       { indexed: true, name: "owner", type: "address" },
+ *       { indexed: true, name: "spender", type: "address" },
+ *       { indexed: false, name: "value", type: "uint256" },
+ *     ],
+ *   },
+ * ] as const;
+ *
+ * const preppedArgs = objectToArray({
+ *   abi,
+ *   type: "function",
+ *   name: "transfer",
+ *   kind: "inputs",
+ *   value: { value: 123n, to: "0x123" },
+ * }); // -> ["0x123", 123n]
+ *
+ * const preppedFilter = objectToArray({
+ *   abi,
+ *   type: "event",
+ *   name: "Approval",
+ *   kind: "inputs",
+ *   value: { spender: "0x123" },
+ * }); // -> [undefined, "0x123", undefined]
+ */
+export function objectToArray<
+  TAbi extends Abi,
+  TItemType extends AbiItemType,
+  TName extends AbiEntryName<TAbi, TItemType>,
+  TParameterKind extends AbiParameterKind,
+>({
+  abi,
+  type,
+  name,
+  kind,
+  value,
+}: {
+  abi: TAbi;
+  name: TName;
+  value?: Abi extends TAbi
+    ? Record<string, unknown> // <- fallback for unknown ABI type
+    : Partial<AbiObjectType<TAbi, TItemType, TName, TParameterKind>>;
+  kind: TParameterKind;
+  type: TItemType;
+}): AbiArrayType<TAbi, TItemType, TName, TParameterKind> {
+  const abiEntry = getAbiEntry({ abi, type, name });
+
+  let parameters: AbiParameter[] = [];
+  if (kind in abiEntry) {
+    parameters = (abiEntry as any)[kind];
+  }
+
+  // No parameters
+  if (!parameters.length) {
+    return [] as AbiArrayType<TAbi, TItemType, TName, TParameterKind>;
+  }
+
+  const valueObject: Record<string, unknown> =
+    value && typeof value === 'object' ? value : {};
+
+  const array: unknown[] = [];
+  parameters.forEach(({ name }, i) => {
+    array.push(valueObject[name || i]);
+  });
+
+  return array as AbiArrayType<TAbi, TItemType, TName, TParameterKind>;
+}

--- a/packages/evm-client/src/exports/contract.ts
+++ b/packages/evm-client/src/exports/contract.ts
@@ -46,5 +46,6 @@ export type {
 
 // Utils
 export { arrayToFriendly } from 'src/contract/utils/arrayToFriendly';
-export { friendlyToArray } from 'src/contract/utils/friendlyToArray';
+export { arrayToObject } from 'src/contract/utils/arrayToObject';
 export { getAbiEntry } from 'src/contract/utils/getAbiEntry';
+export { objectToArray } from 'src/contract/utils/objectToArray';

--- a/packages/evm-client/src/exports/contract.ts
+++ b/packages/evm-client/src/exports/contract.ts
@@ -14,6 +14,8 @@ export type {
   AbiEntry,
   AbiEntryName,
   AbiFriendlyType,
+  AbiObjectType,
+  AbiParameters,
 } from 'src/contract/types/AbiEntry';
 export type {
   CachedReadContract,


### PR DESCRIPTION
This changes the type of all inputs (function and event arguments) to objects (`AbiObjectType`) regardless of the number of inputs.

```diff
- const balance = await contract.read("balanceOf", "0x123");
+ const balance = await contract.read("balanceOf", { owner: "0x123" });
```

Output types remain the `AbiFriendlyType` which will only be an object if there are more than one output value. This is because many functions that return a single value, don't have a name for the output which would result in things like `symbol` returning `{ "0": "DAI" }`.