### PR TITLE
Preserve contract prototypes when extending, add `cache` property to cached contracts

### DIFF
--- a/.changeset/lazy-scissors-teach.md
+++ b/.changeset/lazy-scissors-teach.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client": patch
+---
+
+Added a `cache` property to the `CahcedReadContract` type and ensured the factories preserve the prototypes of the contract's they're given.

--- a/.changeset/lazy-scissors-teach.md
+++ b/.changeset/lazy-scissors-teach.md
@@ -2,4 +2,4 @@
 "@delvtech/evm-client": patch
 ---
 
-Added a `cache` property to the `CahcedReadContract` type and ensured the factories preserve the prototypes of the contract's they're given.
+Added a `cache` property to the `CachedReadContract` type and ensured the factories preserve the prototypes of the contract's they're given.

--- a/packages/evm-client/src/contract/factories/createCachedReadContract.ts
+++ b/packages/evm-client/src/contract/factories/createCachedReadContract.ts
@@ -35,6 +35,7 @@ export function createCachedReadContract<TAbi extends Abi = Abi>({
 }: CreateCachedReadContractOptions<TAbi>): CachedReadContract<TAbi> {
   return {
     ...contract,
+    cache,
 
     /**
      * Reads data from the contract. First checks the cache, and if not present,

--- a/packages/evm-client/src/contract/factories/createCachedReadContract.ts
+++ b/packages/evm-client/src/contract/factories/createCachedReadContract.ts
@@ -33,8 +33,15 @@ export function createCachedReadContract<TAbi extends Abi = Abi>({
   cache = createLruSimpleCache({ max: DEFAULT_CACHE_SIZE }),
   namespace,
 }: CreateCachedReadContractOptions<TAbi>): CachedReadContract<TAbi> {
-  return {
-    ...contract,
+  // Because this is part of the public API, we won't know if the original
+  // contract is a plain object or a class instance, so we use Object.create to
+  // preserve the original contract's prototype chain when extending, ensuring
+  // the new contract includes all the original contract's methods and
+  // instanceof checks will still work.
+  const contractPrototype = Object.getPrototypeOf(contract);
+  const newContract = Object.create(contractPrototype);
+
+  const overrides: Partial<CachedReadContract<TAbi>> = {
     cache,
 
     /**
@@ -112,6 +119,8 @@ export function createCachedReadContract<TAbi extends Abi = Abi>({
       cache.clear();
     },
   };
+
+  return Object.assign(newContract, contract, overrides);
 }
 
 async function getOrSet<TValue>({

--- a/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
+++ b/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
@@ -26,11 +26,17 @@ export function createCachedReadWriteContract<TAbi extends Abi = Abi>({
   if (isCached(contract)) {
     return contract;
   }
-
-  return {
-    ...contract,
-    ...createCachedReadContract({ contract, cache, namespace }),
-  };
+  // Because this is part of the public API, we won't know if the original
+  // contract is a plain object or a class instance, so we use Object.create to
+  // preserve the original contract's prototype chain when extending, ensuring
+  // the new contract includes all the original contract's methods and
+  // instanceof checks will still work.
+  const contractPrototype = Object.getPrototypeOf(contract);
+  const newContract = Object.create(contractPrototype);
+  return Object.assign(
+    newContract,
+    createCachedReadContract({ contract, cache, namespace }),
+  );
 }
 
 function isCached<TAbi extends Abi>(

--- a/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
+++ b/packages/evm-client/src/contract/factories/createCachedReadWriteContract.ts
@@ -8,7 +8,7 @@ import { ReadWriteContract } from 'src/contract/types/Contract';
 
 export interface CreateCachedReadWriteContractOptions<TAbi extends Abi = Abi>
   extends CreateCachedReadContractOptions<TAbi> {
-  contract: ReadWriteContract<TAbi> | CachedReadWriteContract<TAbi>;
+  contract: ReadWriteContract<TAbi>;
 }
 
 /**
@@ -22,18 +22,19 @@ export function createCachedReadWriteContract<TAbi extends Abi = Abi>({
   cache,
   namespace,
 }: CreateCachedReadWriteContractOptions<TAbi>): CachedReadWriteContract<TAbi> {
-  const cachedReadContract = isCached(contract)
-    ? contract
-    : createCachedReadContract({ contract, cache, namespace });
+  // Avoid double-caching if given a contract that already has a cache.
+  if (isCached(contract)) {
+    return contract;
+  }
 
   return {
     ...contract,
-    ...cachedReadContract,
+    ...createCachedReadContract({ contract, cache, namespace }),
   };
 }
 
 function isCached<TAbi extends Abi>(
-  contract: ReadWriteContract<TAbi> | CachedReadWriteContract<TAbi>,
+  contract: ReadWriteContract<TAbi>,
 ): contract is CachedReadWriteContract<TAbi> {
   return 'clearCache' in contract;
 }

--- a/packages/evm-client/src/contract/types/CachedContract.ts
+++ b/packages/evm-client/src/contract/types/CachedContract.ts
@@ -5,9 +5,11 @@ import {
   ReadWriteContract,
 } from 'src/contract/types/Contract';
 import { FunctionName } from 'src/contract/types/Function';
+import { SimpleCache } from 'src/exports';
 
 export interface CachedReadContract<TAbi extends Abi = Abi>
   extends ReadContract<TAbi> {
+  cache: SimpleCache;
   namespace?: string;
   clearCache(): void;
   deleteRead<TFunctionName extends FunctionName<TAbi>>(


### PR DESCRIPTION
- Added a `cache` property  to `CachedReadContract`.
- Used `Object.create` when extending contracts to ensure they preserve their prototype chain.