### PR TITLE
Add missing value field to write method

### DIFF
--- a/.changeset/ten-suits-vanish.md
+++ b/.changeset/ten-suits-vanish.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client-viem": patch
+---
+
+Add missing `value` field to readWriteContract.write() method arguments

--- a/packages/evm-client-viem/src/contract/utils/createSimulateContractParameters.ts
+++ b/packages/evm-client-viem/src/contract/utils/createSimulateContractParameters.ts
@@ -14,6 +14,7 @@ export function createSimulateContractParameters(
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
+    value
   } = options || {};
 
   const gasPriceOptions =
@@ -25,6 +26,7 @@ export function createSimulateContractParameters(
     accessList,
     account: from,
     gas,
+    value,
     ...gasPriceOptions,
     nonce: nonce !== undefined ? Number(nonce) : undefined,
   };
@@ -35,6 +37,7 @@ type SimulateContractParameters = {
   account?: `0x${string}`;
   gas?: bigint;
   nonce?: number;
+  value?: bigint;
 } & (
   | { gasPrice?: bigint }
   | { maxFeePerGas?: bigint }


### PR DESCRIPTION
We need to include the `options.value` field in order to send eth in a transaction