### PR TITLE
Fix `NamedEventInput` type

### DIFF
--- a/.changeset/strange-hornets-punch.md
+++ b/.changeset/strange-hornets-punch.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client": patch
+---
+
+Fix error with `NamedEventInput` type which was broken and causing broken downstream types such as `EventFilter`

--- a/packages/evm-client/src/contract/types/Event.ts
+++ b/packages/evm-client/src/contract/types/Event.ts
@@ -19,7 +19,7 @@ type NamedEventInput<
   TAbi extends Abi,
   TEventName extends EventName<TAbi>,
 > = Extract<
-  AbiParameters<TAbi, 'event', TEventName, 'inputs'>,
+  AbiParameters<TAbi, 'event', TEventName, 'inputs'>[number],
   NamedAbiParameter
 >;
 

--- a/packages/evm-client/src/contract/utils/objectToArray.ts
+++ b/packages/evm-client/src/contract/utils/objectToArray.ts
@@ -54,6 +54,7 @@ export function objectToArray<
   TItemType extends AbiItemType,
   TName extends AbiEntryName<TAbi, TItemType>,
   TParameterKind extends AbiParameterKind,
+  TValue extends AbiObjectType<TAbi, TItemType, TName, TParameterKind>,
 >({
   abi,
   type,
@@ -63,11 +64,9 @@ export function objectToArray<
 }: {
   abi: TAbi;
   name: TName;
-  value?: Abi extends TAbi
-    ? Record<string, unknown> // <- fallback for unknown ABI type
-    : Partial<AbiObjectType<TAbi, TItemType, TName, TParameterKind>>;
   kind: TParameterKind;
   type: TItemType;
+  value?: Abi extends TAbi ? Record<string, unknown> : TValue;
 }): AbiArrayType<TAbi, TItemType, TName, TParameterKind> {
   const abiEntry = getAbiEntry({ abi, type, name });
 


### PR DESCRIPTION
While working on https://github.com/delvtech/hyperdrive-frontend/issues/837, I noticed the `filter` property of `ContractReadOptions` was typed as an empty object for all event types. After looking deeper I found the following line in #40 broke the `NamedEventInput` type which broke all downstream types including `EventFilter`: https://github.com/delvtech/evm-client/pull/40/files#diff-86514dc79b03883339fb21e59548e7d5f7441f7e88c6ab3317737666ef96a142R22

This PR fixes the type.