### PR TITLE
Add `status` to Transaction

### DIFF
--- a/.changeset/rotten-geese-cheer.md
+++ b/.changeset/rotten-geese-cheer.md
@@ -1,0 +1,7 @@
+---
+"@delvtech/evm-client-ethers": minor
+"@delvtech/evm-client-viem": minor
+"@delvtech/evm-client": minor
+---
+
+Add status field to Transaction

--- a/packages/evm-client-ethers/src/network/createNetwork.ts
+++ b/packages/evm-client-ethers/src/network/createNetwork.ts
@@ -81,6 +81,9 @@ export function createNetwork(provider: Provider): Network {
         return;
       }
 
+      // status is either 0 (reverted) or 1 (success)
+      const status = !transaction.status ? 'reverted' : 'success';
+
       return {
         blockHash: transaction.blockHash as `0x${string}`,
         blockNumber: BigInt(transaction.blockNumber),
@@ -92,6 +95,7 @@ export function createNetwork(provider: Provider): Network {
         transactionHash: transaction.hash as `0x${string}`,
         transactionIndex: transaction.index,
         effectiveGasPrice: BigInt(transaction.gasPrice),
+        status,
       };
     },
   };

--- a/packages/evm-client-viem/src/network/createNetwork.ts
+++ b/packages/evm-client-viem/src/network/createNetwork.ts
@@ -72,7 +72,7 @@ export function createNetwork(publicClient: PublicClient): Network {
       };
     },
 
-    async waitForTransaction(hash, options) {
+    waitForTransaction(hash, options) {
       return publicClient.waitForTransactionReceipt({
         hash,
         timeout: options?.timeout,

--- a/packages/evm-client-viem/src/network/createNetwork.ts
+++ b/packages/evm-client-viem/src/network/createNetwork.ts
@@ -73,7 +73,7 @@ export function createNetwork(publicClient: PublicClient): Network {
     },
 
     async waitForTransaction(hash, options) {
-      return await publicClient.waitForTransactionReceipt({
+      return publicClient.waitForTransactionReceipt({
         hash,
         timeout: options?.timeout,
       });

--- a/packages/evm-client/src/network/stubs/NetworkStub.ts
+++ b/packages/evm-client/src/network/stubs/NetworkStub.ts
@@ -154,6 +154,7 @@ export function transactionToReceipt(
         transactionHash: transaction.hash!,
         gasUsed: 0n,
         logsBloom: '0x',
+        status: 'success',
       }
     : undefined;
 }

--- a/packages/evm-client/src/network/types/Transaction.ts
+++ b/packages/evm-client/src/network/types/Transaction.ts
@@ -45,6 +45,9 @@ export interface TransactionReceipt {
   logsBloom: `0x${string}`;
   transactionHash: `0x${string}`;
   transactionIndex: number;
+
+  status: 'success' | 'reverted';
+
   /**
    * The actual value per gas deducted from the sender's account. Before
    * EIP-1559, this is equal to the transaction's gas price. After, it is equal


### PR DESCRIPTION
Related to: https://github.com/delvtech/hyperdrive-frontend/issues/931

Getting the status of the transaction will allow us to detect reverts and successful txs.