### PR TITLE
Adds validateBeforeWrite param to createReadWriteContract

### DIFF
--- a/.changeset/rare-tools-drum.md
+++ b/.changeset/rare-tools-drum.md
@@ -2,4 +2,4 @@
 "@delvtech/evm-client-viem": minor
 ---
 
-This is adding a validateBeforeWrite param to createReadWriteContract.
+This added a validateBeforeWrite param to createReadWriteContract.

--- a/.changeset/rare-tools-drum.md
+++ b/.changeset/rare-tools-drum.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client-viem": minor
+---
+
+This is adding a validateBeforeWrite param to createReadWriteContract.

--- a/packages/evm-client-viem/src/contract/createReadWriteContract.ts
+++ b/packages/evm-client-viem/src/contract/createReadWriteContract.ts
@@ -17,7 +17,7 @@ export interface ReadWriteContractOptions<TAbi extends Abi = Abi>
   /**
    * Turn this off for debugging
    */
-  validateBeforeWrite?: boolean;
+  simulateBeforeWrite?: boolean;
 }
 
 /**
@@ -30,7 +30,7 @@ export function createReadWriteContract<TAbi extends Abi = Abi>({
   publicClient,
   walletClient,
   readContract = createReadContract({ abi, address, publicClient }),
-  validateBeforeWrite: validateBeforeWrite = true,
+  simulateBeforeWrite: simulateBeforeWrite = true,
 }: ReadWriteContractOptions<TAbi>): ReadWriteContract<TAbi> {
   return {
     ...readContract,
@@ -63,7 +63,7 @@ export function createReadWriteContract<TAbi extends Abi = Abi>({
         value: args,
       });
 
-      if (!validateBeforeWrite) {
+      if (!simulateBeforeWrite) {
         return walletClient.writeContract({
           address,
           abi: abi as Abi,


### PR DESCRIPTION
This PR adds a validateBeforeWrite param to createReadWriteContract in the viem package in order to turn off simulating a contract before writing. This is useful for debugging contract reverts.