### PR TITLE
Fix bug causing event args to not be sent in eth_getLogs

### DIFF
--- a/.changeset/spotty-waves-allow.md
+++ b/.changeset/spotty-waves-allow.md
@@ -1,0 +1,5 @@
+---
+"@delvtech/evm-client-viem": patch
+---
+
+Fix bug causing event args to not get passed to getEvents requets"

--- a/packages/evm-client-viem/src/contract/createReadContract.ts
+++ b/packages/evm-client-viem/src/contract/createReadContract.ts
@@ -112,6 +112,7 @@ export function createReadContract<TAbi extends Abi = Abi>({
         eventName: eventName as string,
         fromBlock: options?.fromBlock ?? 'earliest',
         toBlock: options?.toBlock ?? 'latest',
+        args: options?.filter,
       });
 
       return events.map(({ args, blockNumber, data, transactionHash }) => {


### PR DESCRIPTION
Followup to #76, we still need to pass args through for event requests.